### PR TITLE
Store temp files in /tmp/vimclip/ (Close #5)

### DIFF
--- a/vimclip
+++ b/vimclip
@@ -11,7 +11,8 @@ if [ "Darwin" = $(uname -s) ]; then
       exit 1
     fi
 
-    TMP=$(mktemp -t vimclip)
+    mkdir -p /tmp/vimclip
+    TMP=$(mktemp -t vimclip/vimclip)
     $EDITOR $TMP
     pbcopy < $TMP
 else
@@ -20,7 +21,8 @@ else
       exit 1
     fi
 
-    TMP=$(mktemp -p /tmp -t vimclip.XXXXXXXX)
+    mkdir -p /tmp/vimclip
+    TMP=$(mktemp -p /tmp/vimclip -t vimclip.XXXXXXXX)
     $EDITOR $TMP
     xsel -i -b < $TMP
 fi


### PR DESCRIPTION
This works on Linux, but I'm not sure about OSX since I don't have a mac to test on and the mktemp documentation I found online didn't provide much info.